### PR TITLE
Fixed issue with switch case trailing-comma reporting

### DIFF
--- a/src/errors/CompilerError.js
+++ b/src/errors/CompilerError.js
@@ -8,6 +8,29 @@
 
 export class CompilerError extends Error {
     /**
+     * @readonly
+     * @type {CompilerErrorKind}
+     */
+    kind
+
+    /**
+     * @readonly
+     * @type {Site}
+     */
+    site
+
+    /**
+     * @readonly
+     * @type {string}
+     * */
+    originalMessage
+
+    /**
+     * @type {CompilerError[] | null}
+     */
+    otherErrors
+
+    /**
      * @param {CompilerErrorKind} kind
      * @param {Site} site
      * @param {string} msg
@@ -17,6 +40,7 @@ export class CompilerError extends Error {
         this.kind = kind
         this.site = site
         this.originalMessage = msg
+        this.otherErrors = null
     }
 
     /**

--- a/src/errors/ErrorCollector.js
+++ b/src/errors/ErrorCollector.js
@@ -25,7 +25,9 @@ export class ErrorCollector {
 
     throw() {
         if (this.errors.length > 0) {
-            throw this.errors[0]
+            const [firstError, ...others] = this.errors
+            firstError.otherErrors = others
+            throw firstError
         }
     }
 }

--- a/src/tokens/Group.js
+++ b/src/tokens/Group.js
@@ -41,16 +41,26 @@ export class Group {
     site
 
     /**
-	 
+     * @readonly
+     * @type {string | null}
+     */
+    error
+
+    /**	 
 	 * @param {string} kind - "(", "[" or "{"
 	 * @param {F[]} fields 
      * @param {SymbolToken[]} separators - useful for more accurate errors
      * @param {TokenSite} site 
 	 */
     constructor(kind, fields, separators, site = TokenSite.dummy()) {
-        if (separators.length != Math.max(fields.length - 1, 0)) {
+        const expectCount = Math.max(fields.length - 1, 0)
+        this.error = null
+        if (separators.length > expectCount) {
+            const separatorType = separators[0].value
+            this.error = `'${kind}' group: excess '${separatorType}' - expected ${expectCount}, got ${separators.length}`
+        } else if (separators.length != expectCount) {
             throw new Error(
-                `expected ${Math.max(fields.length - 1, 0)}, got ${separators.length}`
+                `expected ${expectCount}, got ${separators.length}`
             )
         }
 

--- a/src/tokens/Tokenizer.js
+++ b/src/tokens/Tokenizer.js
@@ -854,8 +854,8 @@ export class Tokenizer {
         }
 
         if (separators.length > 0 && separators.length >= fields.length) {
-            this.addSyntaxError(separators[0].site, `trailing comma`)
-        }
+            this.addSyntaxError(separators[separators.length-1].site, `trailing comma`)
+       }
 
         const groupSite = new TokenSite(
             open.site.file,
@@ -865,7 +865,11 @@ export class Tokenizer {
             endSite ? endSite.column : open.site.column
         )
 
-        return new Group(open.value, fields, separators, groupSite)
+        const group = new Group(open.value, fields, separators, groupSite)
+        if (group.error) {
+            this.addSyntaxError(group.site, group.error)
+        }
+        return group
     }
 
     /**
@@ -912,7 +916,9 @@ export class Tokenizer {
                 }
 
                 const group = this.buildGroup(open, current.concat([t]))
-
+                if (group.error) {
+                    this.addSyntaxError(group.site, group.error)
+                }
                 current = stack.pop() ?? []
 
                 current.push(group)


### PR DESCRIPTION
The Group field/separator-count mismatch error was subsuming the intended error reporting. Now collects the Group error.

 - trailing-comma syntax error points to site of LAST separator, not first
 - Group adds error prop instead of throwing it,
    ... when extra separators are present 
    ... details the kind of group 
    ... and points to the TOP of the group.
 - tokenizer adds syntaxError when a group.error is present
 - this second syntax error is supplementary but correct
 - ErrorCollector now attaches the remainder of its collected errors 
   ... to the error it `throw()`s, as `otherErrors`, so callers 
   ... can present the list of recognized problems to devs