### PR TITLE
proactive pre-release version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@helios-lang/compiler-utils",
-    "version": "0.3.2",
+    "version": "0.4.0",
     "description": "Helios language compiler library",
     "main": "src/index.js",
     "types": "types/index.d.ts",


### PR DESCRIPTION
 - downstream projects in the WORKSPACE need to know this version is breaking the interface they may rely on; they should use npm version, not this workspace version)

TODO: CI should do (or require a person does) this when the interface breaks