### PR TITLE
add moduleName, purpose, [project], [moreInfo] to Source type

### DIFF
--- a/src/formatters/translateImportPath.test.js
+++ b/src/formatters/translateImportPath.test.js
@@ -8,7 +8,9 @@ describe(translateImportPaths.name, () => {
      * @param {string} path
      * @returns {string}
      */
-    const src = (path) => `import { /*weird comment*/ Datum } from ${path}
+    const src = (
+        path
+    ) => `testing importPath\nimport { /*weird comment*/ Datum } from ${path}
     
 func main(datum: Datum, _, _) -> Bool {
     // single-line comment

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,11 @@ export {
  * length is a separate field because of performance
  * @typedef {object} Source
  * @prop {string} content
- * @prop {string} name
+ * @prop {string} name - provided filename (or script name parsed from script header)
+ * @prop {string} moduleName - script/module name, parsed from the script header
+ * @prop {string} purpose - script purpose, parsed from the script header
+ * @prop {string} [project] - optional project name in which the module is defined
+ * @prop {string} [moreInfo] - optional additional info about the source
  * @prop {number} length
  * @prop {number[]} lineEndLocations
  * @prop {(i: number) => string} getChar

--- a/src/tokens/Tokenizer.test.js
+++ b/src/tokens/Tokenizer.test.js
@@ -7,14 +7,14 @@ import { makeTokenizer } from "./Tokenizer.js"
 describe("Tokenizer", () => {
     it("tokenizes #54686543616B654973414C6965 as single ByteArrayLiteral", () => {
         const tokenizer = makeTokenizer(
-            makeSource("#54686543616B654973414C6965")
+            makeSource("testing tokenizer\n#54686543616B654973414C6965")
         )
 
         const tokens = tokenizer.tokenize()
         tokenizer.errors.throw()
 
-        strictEqual(tokens.length, 1)
-        const token = tokens[0]
+        strictEqual(tokens.length, 3)
+        const token = tokens[2]
         strictEqual(token.kind, "bytes")
 
         if (token.kind == "bytes") {
@@ -26,15 +26,17 @@ describe("Tokenizer", () => {
 
     it("tokenizes 000000000000000000000000000000000000012345 as 12345 if leading zeroes is allowed", () => {
         const tokenizer = makeTokenizer(
-            makeSource("000000000000000000000000000000000000012345"),
+            makeSource(
+                "testing tokenizer\n000000000000000000000000000000000000012345"
+            ),
             { allowLeadingZeroes: true }
         )
 
         const tokens = tokenizer.tokenize()
         tokenizer.errors.throw()
 
-        strictEqual(tokens.length, 1)
-        const token = tokens[0]
+        strictEqual(tokens.length, 3)
+        const token = tokens[2]
         strictEqual(token.kind, "int")
 
         if (token.kind == "int") {
@@ -46,7 +48,9 @@ describe("Tokenizer", () => {
 
     it("fails to tokenize 000000000000000000000000000000000000012345 is leading zeroes isn't allowed", () => {
         const tokenizer = makeTokenizer(
-            makeSource("000000000000000000000000000000000000012345"),
+            makeSource(
+                "testing tokenizer\n000000000000000000000000000000000000012345"
+            ),
             { allowLeadingZeroes: false }
         )
 


### PR DESCRIPTION
 - parses moduleName, purpose from script content
 - "unknown" no longer used as fallback for script `name`